### PR TITLE
Reduce action workflow parallel runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     name: ${{ matrix.session }} ${{ matrix.python }} / ${{ matrix.os }}


### PR DESCRIPTION
Try to limit workflow runs to run at the same time if they need to, but not more than one per branch at a time,