### PR TITLE
Add workflow to automerge dependabot minor and patch PRs 

### DIFF
--- a/.github/workflows/auto-merge-dependabot-workflow.yaml
+++ b/.github/workflows/auto-merge-dependabot-workflow.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           # Create a personal access token and store it under the Secrets section of the particular repository
           # with the key "GITHUB_ACTIONS_TOKEN"
-          github-token: ${{ secrets.GITHUB_ACTIONS_TOKEN }}
+          github-token: ${{ secrets.DEPENDABOT_ACTIONS_SECRET }}
       - name: Auto merge
         uses: pascalgn/automerge-action@22948e0bc22f0aa673800da838595a3e7347e584 # v0.15.6
         # Perform the auto merge action only when the PR is raised by dependabot for patch or minor
@@ -35,7 +35,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
           (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')}}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_ACTIONS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.DEPENDABOT_ACTIONS_SECRET }}
           # Whenever dependabot raises a PR, it automatically assigns a label named "dependencies"
           # Merges those PRs labelled "dependencies" only
           MERGE_LABELS: dependencies

--- a/.github/workflows/auto-merge-dependabot-workflow.yaml
+++ b/.github/workflows/auto-merge-dependabot-workflow.yaml
@@ -1,0 +1,42 @@
+name: Auto approve and merge PRs by dependabot
+
+# Trigger the workflow on pull request
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-approve:
+    name: Auto Approve a PR by dependabot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@cd6e996708b8cfe0b639401134a3b9a3177be7b2 # v1.5.1
+      - name: Auto approve patch and minor
+        if: |
+          ${{(steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')}}
+        uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+        # Perform the auto-approve action only when the PR is raised by dependabot
+        # and is a minor or patch
+        with:
+          # Create a personal access token and store it under the Secrets section of the particular repository
+          # with the key "GITHUB_ACTIONS_TOKEN"
+          github-token: ${{ secrets.GITHUB_ACTIONS_TOKEN }}
+      - name: Auto merge
+        uses: pascalgn/automerge-action@22948e0bc22f0aa673800da838595a3e7347e584 # v0.15.6
+        # Perform the auto merge action only when the PR is raised by dependabot for patch or minor
+        if: |
+          ${{(steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          (github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]')}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_ACTIONS_TOKEN }}
+          # Whenever dependabot raises a PR, it automatically assigns a label named "dependencies"
+          # Merges those PRs labelled "dependencies" only
+          MERGE_LABELS: dependencies
+          MERGE_METHOD: rebase

--- a/docs/architectural_decision_records/012-auto-merge-dependabot.md
+++ b/docs/architectural_decision_records/012-auto-merge-dependabot.md
@@ -1,0 +1,41 @@
+# 12. Automated Merging of Dependabot PRs for Minor and Patch Dependency Updates
+
+## Status
+
+Approved
+
+## Context
+
+We have an open-source software (OSS) project written in Python with a solid test suite. As an OSS project,
+it's important for us to keep our dependencies up to date to ensure security, stability, and performance
+improvements. Dependabot is a popular tool that automatically creates pull requests (PRs) to update our
+project's dependencies to their latest minor and patch versions.
+
+Currently, the process of merging these Dependabot PRs is manual and time-consuming, requiring manual review
+and validation. This manual intervention is not only labor-intensive but also prone to human errors and delays,
+resulting in outdated dependencies that could potentially impact the efficiency and security of our software.
+
+To improve the efficiency of our software development process, we propose implementing a GitHub Actions workflow
+that automatically merges Dependabot PRs for minor and patch dependency updates, given that our project has a
+robust test suite in place. This workflow will help ensure that our dependencies are promptly updated, minimizing
+the effort required for manual intervention while maintaining a high level of confidence in the code quality.
+
+## Decision
+
+We will implement a GitHub Actions workflow to automatically merge Dependabot PRs for minor and patch dependency
+updates in our project.
+
+## Consequences
+
+### Benefits
+
+1. **Improved efficiency:** The automated merging of Dependabot PRs will reduce the manual effort required to review and validate each update, freeing up developers' time for more value-added activities.
+2. **Timely updates:** With automated merging, the process of updating dependencies will be streamlined, allowing us to promptly incorporate the latest minor and patch releases. This ensures that our software benefits from the latest bug fixes, security patches, and performance improvements.
+3. **Reduced human error:** Automation reduces the risk of human errors during the merging process, as it follows a consistent and predefined set of rules. This minimizes the chances of overlooking important updates or introducing unintentional mistakes while merging.
+4. **Maintained code quality:** By requiring a solid test suite for the project, we can have confidence that the automatic merging of Dependabot PRs will not introduce breaking changes or regressions. Our test suite acts as a safeguard against potential issues caused by updated dependencies.
+
+### Risks and Mitigations
+
+1. **False positives:** There is a risk of the automated merging incorrectly merging a Dependabot PR that introduces a regression or a compatibility issue. To mitigate this risk, we will ensure that our test suite provides comprehensive coverage and includes relevant integration and regression tests.
+2. **Conflict resolution:** In case of conflicts between a Dependabot PR and our project's codebase, the automated merging may fail. We will monitor the workflow execution and promptly address any conflicts that arise. Additionally, we will ensure that the project's codebase adheres to best practices such as modular architecture and decoupling to minimize potential conflicts.
+3. **Lack of test coverage:** If our test suite is not extensive enough or lacks proper coverage, the automated merging could inadvertently introduce issues that go unnoticed. We will regularly review and enhance our test suite to ensure it adequately tests the project's critical functionality and edge cases.


### PR DESCRIPTION
Let the machine auto-merge patch and minor dependabot PRs, like we do for Renovate PRs