### PR TITLE
Fix for timezone-aware vs timezone-naive datetime comparison

### DIFF
--- a/sample-config.toml
+++ b/sample-config.toml
@@ -5,6 +5,7 @@ title = "Sample devops-deployment-metrics configuration"
     time-slice-days = 7
     start-date = 2022-06-01T00:01:00
     date-format = "%Y-%m-%d"
+    timezone = "UTC"
 
 [[repositories]]
     owner = "my_github_owner"

--- a/src/devops_deployment_metrics/config.py
+++ b/src/devops_deployment_metrics/config.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import toml
 from devops_deployment_metrics.workflow import Workflow
@@ -32,8 +33,14 @@ def get_config(config_path: Path) -> Config:
         )
         for wf in cfg["repositories"]
     ]
+    timezone = (
+        ZoneInfo(cfg["general"]["timezone"])
+        if "timezone" in cfg["general"]
+        else ZoneInfo("UTC")
+    )
+    start_date = cfg["general"]["start-date"].replace(tzinfo=timezone)
     return Config(
-        cfg["general"]["start-date"],
+        start_date,
         cfg["general"]["time-slice-days"],
         cfg["general"]["date-format"],
         wdefs,

--- a/src/devops_deployment_metrics/metrics.py
+++ b/src/devops_deployment_metrics/metrics.py
@@ -2,6 +2,7 @@
 from dataclasses import asdict
 from datetime import datetime
 from datetime import timedelta
+from datetime import timezone
 from typing import Any
 from typing import Iterable
 from typing import Optional
@@ -50,7 +51,9 @@ class Metric:
         end_period: Optional[datetime] = None,
     ) -> Iterable[tuple[datetime, list[WorkflowRun]]]:
         """Get the deployments for each period."""
-        end_period = end_period or datetime.now()
+        # Using this workaround to get the current datetime with the local timezone
+        now = datetime.now(timezone.utc).astimezone()
+        end_period = end_period or now
         end_date = start_date + timedelta(days=days_slice)
 
         while start_date <= end_period:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ title = "Sample devops-deployment-metrics configuration"
     time-slice-days = 7
     start-date = 2022-06-01T00:01:00
     date-format = "%Y-%m-%d"
+    timezone = "UTC"
 
 [[repositories]]
     owner = "my_github_owner"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,9 @@ def test_config(config_path: Path) -> None:
     config = get_config(config_path)
 
     assert isinstance(config, Config)
-    assert config.start_date == datetime.datetime(2022, 6, 1, 0, 1)
+    assert config.start_date == datetime.datetime(
+        2022, 6, 1, 0, 1, tzinfo=datetime.timezone.utc
+    )
     assert config.days_slice == 7
     assert config.date_format == "%Y-%m-%d"
     assert len(config.workflows) == 2

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
 """Test the metrics module."""
 from dataclasses import asdict
 from datetime import datetime
+from datetime import timezone
 from pathlib import Path
 
 import pytest
@@ -29,10 +30,10 @@ def deployments() -> list[WorkflowRun]:
             id=1,
             status="completed",
             conclusion="success",
-            run_started=datetime(2022, 6, 1, 0, 1),
+            run_started=datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 1, 0, 1),
-            updated_at=datetime(2022, 6, 1, 0, 1),
+            created_at=datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/111",
         ),
@@ -40,10 +41,10 @@ def deployments() -> list[WorkflowRun]:
             id=2,
             status="completed",
             conclusion="success",
-            run_started=datetime(2022, 6, 1, 10, 1),
+            run_started=datetime(2022, 6, 1, 10, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 1, 10, 1),
-            updated_at=datetime(2022, 6, 1, 10, 1),
+            created_at=datetime(2022, 6, 1, 10, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 1, 10, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/222",
         ),
@@ -51,10 +52,10 @@ def deployments() -> list[WorkflowRun]:
             id=3,
             status="completed",
             conclusion="failure",
-            run_started=datetime(2022, 6, 3, 0, 1),
+            run_started=datetime(2022, 6, 3, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 3, 0, 1),
-            updated_at=datetime(2022, 6, 3, 0, 1),
+            created_at=datetime(2022, 6, 3, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 3, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/333",
         ),
@@ -62,10 +63,10 @@ def deployments() -> list[WorkflowRun]:
             id=4,
             status="completed",
             conclusion="success",
-            run_started=datetime(2022, 6, 4, 0, 1),
+            run_started=datetime(2022, 6, 4, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 4, 0, 1),
-            updated_at=datetime(2022, 6, 4, 0, 1),
+            created_at=datetime(2022, 6, 4, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 4, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/444",
         ),
@@ -73,10 +74,10 @@ def deployments() -> list[WorkflowRun]:
             id=5,
             status="completed",
             conclusion="failure",
-            run_started=datetime(2022, 6, 5, 0, 1),
+            run_started=datetime(2022, 6, 5, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 5, 0, 1),
-            updated_at=datetime(2022, 6, 5, 0, 1),
+            created_at=datetime(2022, 6, 5, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 5, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/555",
         ),
@@ -84,10 +85,10 @@ def deployments() -> list[WorkflowRun]:
             id=6,
             status="completed",
             conclusion="success",
-            run_started=datetime(2022, 6, 7, 0, 1),
+            run_started=datetime(2022, 6, 7, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 7, 0, 1),
-            updated_at=datetime(2022, 6, 7, 0, 1),
+            created_at=datetime(2022, 6, 7, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 7, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/666",
         ),
@@ -95,10 +96,10 @@ def deployments() -> list[WorkflowRun]:
             id=7,
             status="completed",
             conclusion="failure",
-            run_started=datetime(2022, 6, 9, 0, 1),
+            run_started=datetime(2022, 6, 9, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 9, 0, 1),
-            updated_at=datetime(2022, 6, 9, 0, 1),
+            created_at=datetime(2022, 6, 9, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 9, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/192021",
         ),
@@ -106,10 +107,10 @@ def deployments() -> list[WorkflowRun]:
             id=8,
             status="completed",
             conclusion="failure",
-            run_started=datetime(2022, 6, 10, 0, 1),
+            run_started=datetime(2022, 6, 10, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 10, 0, 1),
-            updated_at=datetime(2022, 6, 10, 0, 1),
+            created_at=datetime(2022, 6, 10, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 10, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/192021",
         ),
@@ -117,10 +118,10 @@ def deployments() -> list[WorkflowRun]:
             id=9,
             status="completed",
             conclusion="other_conclusion",
-            run_started=datetime(2022, 6, 11, 0, 1),
+            run_started=datetime(2022, 6, 11, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 11, 0, 1),
-            updated_at=datetime(2022, 6, 11, 0, 1),
+            created_at=datetime(2022, 6, 11, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 11, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/888",
         ),
@@ -128,10 +129,10 @@ def deployments() -> list[WorkflowRun]:
             id=10,
             status="completed",
             conclusion="failure",
-            run_started=datetime(2022, 6, 14, 0, 1),
+            run_started=datetime(2022, 6, 14, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 14, 0, 1),
-            updated_at=datetime(2022, 6, 14, 0, 1),
+            created_at=datetime(2022, 6, 14, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 14, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/999",
         ),
@@ -139,10 +140,10 @@ def deployments() -> list[WorkflowRun]:
             id=11,
             status="completed",
             conclusion="success",
-            run_started=datetime(2022, 6, 16, 0, 1),
+            run_started=datetime(2022, 6, 16, 0, 1, tzinfo=timezone.utc),
             run_attempt=1,
-            created_at=datetime(2022, 6, 16, 0, 1),
-            updated_at=datetime(2022, 6, 16, 0, 1),
+            created_at=datetime(2022, 6, 16, 0, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2022, 6, 16, 0, 1, tzinfo=timezone.utc),
             head_branch="main",
             url="https://github.com/test/test/actions/runs/999",
         ),
@@ -154,15 +155,15 @@ def test_metric(config: Config) -> None:
     metric_type = MetricName.DEPLOYMENT_FREQUENCY
     metric = Metric(metric_type, config)
     assert metric.name == metric_type
-    assert metric.start_date == datetime(2022, 6, 1, 0, 1)
+    assert metric.start_date == datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
     assert metric.days_slice == 7
     assert metric.date_format == "%Y-%m-%d"
 
 
 def test_get_deployments_in_period(deployments: list[WorkflowRun]) -> None:
     """Test the get_deployments_in_period method."""
-    start_date = datetime(2022, 6, 1, 0, 1)
-    end_period = datetime(2022, 6, 15, 0, 1)
+    start_date = datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
+    end_period = datetime(2022, 6, 15, 0, 1, tzinfo=timezone.utc)
     days_slice = 7
     runs = list(
         Metric.get_deployments_in_period(
@@ -173,17 +174,17 @@ def test_get_deployments_in_period(deployments: list[WorkflowRun]) -> None:
     assert len(runs) == 3
 
     run1_start_date, run1_deployments = runs[0]
-    assert run1_start_date == datetime(2022, 6, 1, 0, 1)
+    assert run1_start_date == datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
     assert len(run1_deployments) == 6
     assert run1_deployments[0].id == 1
 
     run2_start_date, run2_deployments = runs[1]
-    assert run2_start_date == datetime(2022, 6, 8, 0, 1)
+    assert run2_start_date == datetime(2022, 6, 8, 0, 1, tzinfo=timezone.utc)
     assert len(run2_deployments) == 4
     assert run2_deployments[0].id == 7
 
     run3_start_date, run3_deployments = runs[2]
-    assert run3_start_date == datetime(2022, 6, 15, 0, 1)
+    assert run3_start_date == datetime(2022, 6, 15, 0, 1, tzinfo=timezone.utc)
     assert len(run3_deployments) == 1
     assert run3_deployments[0].id == 11
 
@@ -197,15 +198,15 @@ def test_deployment_frequency_metric(
 
     results = metric.calculate(deployments)
 
-    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1)
+    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
     assert round(results[0]["frequency"], 2) == 0.57
     assert results[0]["count"] == 4
 
-    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1)
+    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1, tzinfo=timezone.utc)
     assert round(results[1]["frequency"], 2) == 0
     assert results[1]["count"] == 0
 
-    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1)
+    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1, tzinfo=timezone.utc)
     assert round(results[2]["frequency"], 2) == 0.14
     assert results[2]["count"] == 1
 
@@ -219,13 +220,13 @@ def test_change_fail_rate_metric(
 
     results = metric.calculate(deployments)
 
-    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1)
+    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
     assert round(results[0]["percent"], 2) == 33.33
 
-    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1)
+    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1, tzinfo=timezone.utc)
     assert round(results[1]["percent"], 2) == 75.0
 
-    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1)
+    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1, tzinfo=timezone.utc)
     assert round(results[2]["percent"], 2) == 0.0
 
 
@@ -238,13 +239,13 @@ def test_mean_time_to_recovery_metric(
 
     results = metric.calculate(deployments)
 
-    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1)
+    assert results[0]["date"] == datetime(2022, 6, 1, 0, 1, tzinfo=timezone.utc)
     assert round(results[0]["mttr"], 2) == 36.0
 
-    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1)
+    assert results[1]["date"] == datetime(2022, 6, 8, 0, 1, tzinfo=timezone.utc)
     assert round(results[1]["mttr"], 2) == 0.0
 
-    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1)
+    assert results[2]["date"] == datetime(2022, 6, 15, 0, 1, tzinfo=timezone.utc)
     assert round(results[2]["mttr"], 2) == 168.0
 
 


### PR DESCRIPTION
This PR fixes #289. The bug was caused by comparing datetimes with and without timezone defined in line 62 of `src/devops_deployment_metrics/metrics.py`:
```
if start_date <= deployment.run_started < end_date
```
Where `start_date` and `end_date` were timezone-naive and `deployment.run_started` is timezone-aware

Fixed by adding timezone awareness to all datetime objects